### PR TITLE
DOPS-182: Detect group deleted outside terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@
 
 **Merged pull requests:**
 
-- added import docs and warning to privilege description [\#41](https://github.com/brainly/terraform-provider-redshift/pull/41) ([mtesch-um](https://github.com/mtesch-um))
+- Fix typo in code - wrong variable referenced [\#48](https://github.com/brainly/terraform-provider-redshift/pull/48) ([matokovacik](https://github.com/matokovacik))
 
 ## [v0.5.2](https://github.com/brainly/terraform-provider-redshift/tree/v0.5.2) (2022-01-26)
 
@@ -109,10 +109,9 @@
 
 **Merged pull requests:**
 
-- Fix typo in code - wrong variable referenced [\#48](https://github.com/brainly/terraform-provider-redshift/pull/48) ([matokovacik](https://github.com/matokovacik))
 - Remove CASCADE from ALTER DEFAULT when dropping users and groups [\#47](https://github.com/brainly/terraform-provider-redshift/pull/47) ([winglot](https://github.com/winglot))
 - Move the superuser/password validation to CustomizeDiff func [\#44](https://github.com/brainly/terraform-provider-redshift/pull/44) ([winglot](https://github.com/winglot))
-- Require password for superuser at plan phase [\#39](https://github.com/brainly/terraform-provider-redshift/pull/39) ([winglot](https://github.com/winglot))
+- added import docs and warning to privilege description [\#41](https://github.com/brainly/terraform-provider-redshift/pull/41) ([mtesch-um](https://github.com/mtesch-um))
 
 ## [v0.5.1](https://github.com/brainly/terraform-provider-redshift/tree/v0.5.1) (2021-12-30)
 
@@ -125,6 +124,7 @@
 **Merged pull requests:**
 
 - Deprecate redshift\_privilege resource [\#40](https://github.com/brainly/terraform-provider-redshift/pull/40) ([winglot](https://github.com/winglot))
+- Require password for superuser at plan phase [\#39](https://github.com/brainly/terraform-provider-redshift/pull/39) ([winglot](https://github.com/winglot))
 
 ## [v0.5.0](https://github.com/brainly/terraform-provider-redshift/tree/v0.5.0) (2021-12-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
-## [v1.0.2-1](https://github.com/brainly/terraform-provider-redshift/tree/v1.0.2-1) (2022-09-28)
+## [v1.0.4](https://github.com/brainly/terraform-provider-redshift/tree/v1.0.4) (2022-12-28)
 
-[Full Changelog](https://github.com/brainly/terraform-provider-redshift/compare/v1.0.2...v1.0.2-1)
+[Full Changelog](https://github.com/brainly/terraform-provider-redshift/compare/v1.0.3...v1.0.4)
+
+**Merged pull requests:**
+
+- Fix userSessionTimeoutAttr condition [\#102](https://github.com/brainly/terraform-provider-redshift/pull/102) ([robertomczak](https://github.com/robertomczak))
+- Add SESSION TIMEOUT support and missing defer rows.Close\(\) [\#101](https://github.com/brainly/terraform-provider-redshift/pull/101) ([robertomczak](https://github.com/robertomczak))
+
+## [v1.0.3](https://github.com/brainly/terraform-provider-redshift/tree/v1.0.3) (2022-11-15)
+
+[Full Changelog](https://github.com/brainly/terraform-provider-redshift/compare/v1.0.2...v1.0.3)
+
+**Fixed bugs:**
+
+- Non-idempotent reapplying grants for entities with ascii chars 33-126 in their names [\#94](https://github.com/brainly/terraform-provider-redshift/issues/94)
 
 **Closed issues:**
 
@@ -10,6 +23,7 @@
 
 **Merged pull requests:**
 
+- Fix - preventing from non-idempotent reapplying grants for entities with ascii chars 33-126 in their names [\#93](https://github.com/brainly/terraform-provider-redshift/pull/93) ([rg00d](https://github.com/rg00d))
 - Improve docs for redshift\_datashare\_privilege resource [\#77](https://github.com/brainly/terraform-provider-redshift/pull/77) ([szemek](https://github.com/szemek))
 
 ## [v1.0.2](https://github.com/brainly/terraform-provider-redshift/tree/v1.0.2) (2022-09-02)
@@ -87,7 +101,7 @@
 
 **Merged pull requests:**
 
-- Fix typo in code - wrong variable referenced [\#48](https://github.com/brainly/terraform-provider-redshift/pull/48) ([matokovacik](https://github.com/matokovacik))
+- added import docs and warning to privilege description [\#41](https://github.com/brainly/terraform-provider-redshift/pull/41) ([mtesch-um](https://github.com/mtesch-um))
 
 ## [v0.5.2](https://github.com/brainly/terraform-provider-redshift/tree/v0.5.2) (2022-01-26)
 
@@ -95,9 +109,10 @@
 
 **Merged pull requests:**
 
+- Fix typo in code - wrong variable referenced [\#48](https://github.com/brainly/terraform-provider-redshift/pull/48) ([matokovacik](https://github.com/matokovacik))
 - Remove CASCADE from ALTER DEFAULT when dropping users and groups [\#47](https://github.com/brainly/terraform-provider-redshift/pull/47) ([winglot](https://github.com/winglot))
 - Move the superuser/password validation to CustomizeDiff func [\#44](https://github.com/brainly/terraform-provider-redshift/pull/44) ([winglot](https://github.com/winglot))
-- added import docs and warning to privilege description [\#41](https://github.com/brainly/terraform-provider-redshift/pull/41) ([mtesch-um](https://github.com/mtesch-um))
+- Require password for superuser at plan phase [\#39](https://github.com/brainly/terraform-provider-redshift/pull/39) ([winglot](https://github.com/winglot))
 
 ## [v0.5.1](https://github.com/brainly/terraform-provider-redshift/tree/v0.5.1) (2021-12-30)
 
@@ -110,7 +125,6 @@
 **Merged pull requests:**
 
 - Deprecate redshift\_privilege resource [\#40](https://github.com/brainly/terraform-provider-redshift/pull/40) ([winglot](https://github.com/winglot))
-- Require password for superuser at plan phase [\#39](https://github.com/brainly/terraform-provider-redshift/pull/39) ([winglot](https://github.com/winglot))
 
 ## [v0.5.0](https://github.com/brainly/terraform-provider-redshift/tree/v0.5.0) (2021-12-10)
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/aws/aws-sdk-go-v2 v1.7.0
 	github.com/aws/aws-sdk-go-v2/config v1.4.1
+	github.com/aws/aws-sdk-go-v2/credentials v1.3.0
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.5.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
@@ -25,7 +26,6 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 // indirect
 	github.com/aws/aws-sdk-go v1.25.3 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.3.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.1.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.2.0 // indirect

--- a/redshift/data_source_redshift_schema_test.go
+++ b/redshift/data_source_redshift_schema_test.go
@@ -43,8 +43,9 @@ data "redshift_schema" "schema" {
 
 // Acceptance test for external redshift schema using AWS Glue Data Catalog
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_DATA_CATALOG_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_DATA_CATALOG_IAM_ROLE_ARNS - comma-separated list of ARNs to use
 func TestAccDataSourceRedshiftSchema_ExternalDataCatalog(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE", t)
 	iamRoleArnsRaw := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_IAM_ROLE_ARNS", t)
@@ -95,11 +96,14 @@ data "redshift_schema" "spectrum" {
 
 // Acceptance test for external redshift schema using Hive metastore
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME - hive metastore database endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME - hive metastore database endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_PORT - hive metastore port. Default is 9083
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_PORT - hive metastore port. Default is 9083
 func TestAccDataSourceRedshiftSchema_ExternalHive(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME", t)
@@ -159,13 +163,16 @@ data "redshift_schema" "hive" {
 
 // Acceptance test for external redshift schema using RDS Postgres
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME - RDS endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_IAM_ROLE_ARNS - comma-separated list of ARNs to use
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME - RDS endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_PORT - RDS port. Default is 5432
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SCHEMA - source database schema. Default is "public"
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_PORT - RDS port. Default is 5432
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SCHEMA - source database schema. Default is "public"
 func TestAccDataSourceRedshiftSchema_ExternalRdsPostgres(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME", t)
@@ -234,12 +241,15 @@ data "redshift_schema" "postgres" {
 
 // Acceptance test for external redshift schema using RDS Mysql
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME - RDS endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_IAM_ROLE_ARNS - comma-separated list of ARNs to use
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME - RDS endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_PORT - RDS port. Default is 3306
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_PORT - RDS port. Default is 3306
 func TestAccDataSourceRedshiftSchema_ExternalRdsMysql(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME", t)
@@ -302,9 +312,12 @@ data "redshift_schema" "mysql" {
 
 // Acceptance test for external redshift schema using datashare database
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE - source database name
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE - source database name
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA - datashare schema name. Default is "public"
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA - datashare schema name. Default is "public"
 func TestAccDataSourceRedshiftSchema_ExternalRedshift(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE", t)
 	dbSchema := os.Getenv("REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA")

--- a/redshift/resource_redshift_schema_test.go
+++ b/redshift/resource_redshift_schema_test.go
@@ -151,8 +151,9 @@ resource "redshift_user" "schema_dl_user1" {
 
 // Acceptance test for external redshift schema using AWS Glue Data Catalog
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_IAM_ROLE_ARNS - comma-separated list of ARNs to use
 func TestAccRedshiftSchema_ExternalDataCatalog(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE", t)
 	iamRoleArnsRaw := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_IAM_ROLE_ARNS", t)
@@ -207,11 +208,14 @@ resource "redshift_schema" "spectrum" {
 
 // Acceptance test for external redshift schema using Hive metastore
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME - hive metastore database endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME - hive metastore database endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_PORT - hive metastore port. Default is 9083
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_PORT - hive metastore port. Default is 9083
 func TestAccRedshiftSchema_ExternalHive(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME", t)
@@ -275,13 +279,16 @@ resource "redshift_schema" "hive" {
 
 // Acceptance test for external redshift schema using RDS Postgres
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME - RDS endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_IAM_ROLE_ARNS - comma-separated list of ARNs to use
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME - RDS endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_PORT - RDS port. Default is 5432
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SCHEMA - source database schema. Default is "public"
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_PORT - RDS port. Default is 5432
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SCHEMA - source database schema. Default is "public"
 func TestAccRedshiftSchema_ExternalRdsPostgres(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME", t)
@@ -354,12 +361,15 @@ resource "redshift_schema" "postgres" {
 
 // Acceptance test for external redshift schema using RDS Mysql
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME - RDS endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_IAM_ROLE_ARNS - comma-separated list of ARNs to use
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME - RDS endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_PORT - RDS port. Default is 3306
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_PORT - RDS port. Default is 3306
 func TestAccRedshiftSchema_ExternalRdsMysql(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME", t)
@@ -426,9 +436,12 @@ resource "redshift_schema" "mysql" {
 
 // Acceptance test for external redshift schema using datashare database
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE - source database name
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE - source database name
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA - datashare schema name. Default is "public"
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA - datashare schema name. Default is "public"
 func TestAccRedshiftSchema_ExternalRedshift(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE", t)
 	dbSchema := os.Getenv("REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA")


### PR DESCRIPTION
~Not sure how to test this will fix the issue without releasing it first~
Tested this by creating group in terraform and deleting it manually. Then the next terraform apply gives this plan
```
-------------------------------------------------------------------------
test-redshift-extention: Perform terraform validate
-------------------------------------------------------------------------
Success! The configuration is valid.


-------------------------------------------------------------------------
test-redshift-extention: Perform terraform plan
-------------------------------------------------------------------------
random_password.reporting_service_account_passwords["service_account__tableau"]: Refreshing state... [id=none]
random_password.etl_service_account_passwords["service_account__tableau"]: Refreshing state... [id=none]
module.etl_service_accounts.redshift_group.group: Refreshing state... [id=330067]
module.reporting_database_owners_wlm_group_memberships.redshift_group_membership.group_membership: Refreshing state... [id=330067]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.etl_service_accounts.redshift_group.group has been deleted
  - resource "redshift_group" "group" {
      - id    = "330067" -> null
      - name  = "paul_test_group" -> null
      - users = [
          - "owner__sources_fivetran",
        ] -> null
    }

  # module.reporting_database_owners_wlm_group_memberships.redshift_group_membership.group_membership has been deleted
  - resource "redshift_group_membership" "group_membership" {
      - group_name = "paul_test_group" -> null
      - id         = "330067" -> null
      - users      = [
          - "owner__sources_fivetran",
        ] -> null
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.etl_service_accounts.redshift_group.group will be created
  + resource "redshift_group" "group" {
      + id    = (known after apply)
      + name  = "paul_test_group"
      + users = [
          + "owner__sources_fivetran",
        ]
    }

  # module.reporting_database_owners_wlm_group_memberships.redshift_group_membership.group_membership will be created
  + resource "redshift_group_membership" "group_membership" {
      + group_name = "paul_test_group"
      + id         = (known after apply)
      + users      = [
          + "owner__sources_fivetran",
        ]
    }

Plan: 2 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Saved the plan to: terraform.plan

```